### PR TITLE
Set up Cursor Cloud dev environment (Bun/Astro)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a single static website (Astro + React islands + Tailwind), built and run with **Bun** (see `bun.lock` and `package.json`). There is no backend service or database.
+
+### Runtime
+- Bun is required (the `node` on the VM is only used incidentally). Bun is installed at `~/.bun/bin/bun`; if `bun` is not on `PATH` in a fresh shell, invoke it as `~/.bun/bin/bun` or run `source ~/.bashrc`.
+- Standard commands live in `package.json` scripts — use those rather than duplicating: `bun dev`, `bun run build`, `bun run lint`.
+
+### Dev server
+- `bun dev` serves on `http://localhost:4321/`.
+- `astro.config.mjs` sets `trailingSlash: 'always'`, so sub-pages must be requested with a trailing slash (e.g. `/store/`, not `/store`). Requesting without the slash returns a 404 with a redirect suggestion — this is expected, not a bug.
+
+### Lint / type check
+- `bun run lint` runs ESLint over `src` with `--max-warnings 0`.
+- `bunx astro check` runs the Astro/TypeScript diagnostics (mirrors the CI "Type check" step).
+
+### Build
+- `bun run build` first runs `scripts/fetchproductfeed.mjs`, which fetches the live Zazzle RSS feed over the network and overwrites `src/customizations/productfeed.json`, then runs `astro build` into `dist/`. Network access to `feeds.zazzle.com` is needed for the fetch step; if offline, the existing committed `productfeed.json` is used and only the feed refresh is skipped.
+
+### Third-party integrations
+- The contact form (FormSpree) and subscribe form (ConvertKit) post to external endpoints configured in `src/customizations/siteproperties.json`. Filling them works locally, but successful submission depends on those external services.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Astro + React + Tailwind static site (built/run with Bun) and verifies it end-to-end.

- Installs Bun and project dependencies (`bun install`).
- Verifies lint (`bun run lint`), type check (`bunx astro check`), production build (`bun run build`), and the dev server (`bun dev` on `:4321`).
- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting the runtime, dev/lint/build commands, the `trailingSlash: 'always'` gotcha, and the network-dependent Zazzle feed fetch during build.

The registered startup update script is `~/.bun/bin/bun install` (minimal, idempotent).

## Verification

| Step | Command | Result |
|------|---------|--------|
| Lint | `bun run lint` | pass (0 warnings) |
| Type check | `bunx astro check` | 0 errors / 0 warnings / 0 hints |
| Build | `bun run build` | fetched live product feed + built `dist/` |
| Dev server | `bun dev` | HTTP 200 on `/` and `/store/` |

Hello-world test: loaded the homepage, filled the contact form (React island), and viewed the store product page.

[astro_site_dev_demo.mp4](https://cursor.com/agents/bc-b315b492-46b7-4ba1-a851-e73dc5e5769f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fastro_site_dev_demo.mp4)

[Homepage hero](https://cursor.com/agents/bc-b315b492-46b7-4ba1-a851-e73dc5e5769f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_hero.webp)
[Contact form filled](https://cursor.com/agents/bc-b315b492-46b7-4ba1-a851-e73dc5e5769f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcontact_form_filled.webp)
[Store page](https://cursor.com/agents/bc-b315b492-46b7-4ba1-a851-e73dc5e5769f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstore_page.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b315b492-46b7-4ba1-a851-e73dc5e5769f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b315b492-46b7-4ba1-a851-e73dc5e5769f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

