### PR TITLE
Expose store product descriptions to touch users (#17)

### DIFF
--- a/src/components/Products.astro
+++ b/src/components/Products.astro
@@ -40,7 +40,7 @@ const items = productFeed?.item
                 alt={item.title}
                 class="product-image"
               />
-              <div class="product-hover-banner">
+              <div class="product-info-banner">
                 <span class="product-title">{item['media:title']}</span>
                 <span class="product-description">
                   {truncateDescription(cleanDescription(item['media:description']))}

--- a/src/components/Products.css
+++ b/src/components/Products.css
@@ -45,12 +45,9 @@
     @apply opacity-100;
 }
 
-/* Touch / coarse pointers have no persistent hover — keep info visible */
+/* Touch / coarse pointers have no persistent hover — keep info visible.
+   Do not dim the image by default; that remains a hover/focus cue. */
 @media (hover: none) {
-    .product-image {
-        @apply opacity-70;
-    }
-
     .product-info-banner {
         @apply opacity-100;
     }

--- a/src/components/Products.css
+++ b/src/components/Products.css
@@ -15,12 +15,11 @@
 }
 
 .product-image {
-    @apply w-full;
+    @apply w-full transition-opacity duration-300;
 }
 
-/* Convert styles to Tailwind with @apply directives */
-.product-hover-banner {
-    @apply absolute bottom-0 left-0 right-0 bg-black p-2 opacity-0;
+.product-info-banner {
+    @apply absolute bottom-0 left-0 right-0 bg-black/60 p-2 opacity-0 transition-opacity duration-300;
 }
 
 .product-title {
@@ -35,10 +34,24 @@
     @apply text-center py-2 font-bold;
 }
 
-.product-item:hover .product-image {
+/* Reveal title + description on pointer hover or keyboard focus */
+.product-item:hover .product-image,
+.product-item:focus-within .product-image {
     @apply opacity-70;
 }
 
-.product-item:hover .product-hover-banner {
-    @apply opacity-100 bg-opacity-60;
+.product-item:hover .product-info-banner,
+.product-item:focus-within .product-info-banner {
+    @apply opacity-100;
+}
+
+/* Touch / coarse pointers have no persistent hover — keep info visible */
+@media (hover: none) {
+    .product-image {
+        @apply opacity-70;
+    }
+
+    .product-info-banner {
+        @apply opacity-100;
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #17

## Problem
Product titles and descriptions only appeared on `:hover`, so touch users never saw them.

## Solution
- Rename the overlay to `product-info-banner` (no longer hover-only).
- Keep the reveal on hover **and** `:focus-within` for pointer/keyboard users.
- Under `@media (hover: none)`, always show the banner so coarse/touch pointers get title + description without needing a hover state.
- Dim the product image only on hover/focus — not as the touch default.
- Add opacity transitions so the reveal feels consistent.

## Testing
- `bun run lint` / `bun run typecheck` — clean
- Playwright CDP media emulation:
  - desktop rest → banner hidden, image full opacity
  - desktop hover → banner shown, image dimmed
  - touch rest → banner shown, image full opacity

[Desktop rest — description hidden, full image](https://cursor.com/agents/bc-1de44f6e-aa99-4574-950b-0531e0af6241/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstore-desktop-rest.png)
[Desktop hover — description revealed, image dimmed](https://cursor.com/agents/bc-1de44f6e-aa99-4574-950b-0531e0af6241/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstore-desktop-hover.png)
[Mobile touch — description visible, image not dimmed](https://cursor.com/agents/bc-1de44f6e-aa99-4574-950b-0531e0af6241/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstore-mobile-touch-no-dim.png)
[store-touch-product-descriptions.mp4](https://cursor.com/agents/bc-1de44f6e-aa99-4574-950b-0531e0af6241/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstore-touch-product-descriptions.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1de44f6e-aa99-4574-950b-0531e0af6241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1de44f6e-aa99-4574-950b-0531e0af6241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

