### PR TITLE
Establish design token system with CSS custom properties

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,5 +19,11 @@ This repo is a single static website (Astro + React islands + Tailwind), built a
 ### Build
 - `bun run build` first runs `scripts/fetchproductfeed.mjs`, which fetches the live Zazzle RSS feed over the network and overwrites `src/customizations/productfeed.json`, then runs `astro build` into `dist/`. Network access to `feeds.zazzle.com` is needed for the fetch step; if offline, the existing committed `productfeed.json` is used and only the feed refresh is skipped.
 
+### Design tokens
+- Colour, fonts and panel geometry are defined once, in the `palette` object and `theme.extend` block of `tailwind.config.js`. `src/styles/global.css` republishes them as custom properties (`--color-ink`, `--font-display`, `--panel-border`, …) for hand-written CSS and inline SVG.
+- Prefer the Tailwind utility (`bg-caption`, `border-ink`, `text-accent`) where a class will do; use the custom property where it won't (SVG `style` attributes, `box-shadow`, `color-mix`).
+- Do not introduce new hex literals in `src`. Add the colour to the palette and reference it by name. The one exception is `src/components/SubscribeForm.css`, which is ConvertKit's own widget CSS kept verbatim.
+- Type rule: Bangers (`--font-display`) letters display type — headings, narration, nav, buttons. The sans (`--font-body`) carries reading copy. Allura (`--font-script`) is reserved for the hero tagline. `h1`/`h2`/`h3` are Bangers globally; don't override them per-component.
+
 ### Third-party integrations
 - The contact form (FormSpree) and subscribe form (ConvertKit) post to external endpoints configured in `src/customizations/siteproperties.json`. Filling them works locally, but successful submission depends on those external services.

--- a/src/components/ComicNarration.css
+++ b/src/components/ComicNarration.css
@@ -2,8 +2,8 @@
   position: relative;
   width: 100%;
   height: 100%;
-  font-family: 'Bangers', cursive;
-  color: black;
+  font-family: var(--font-display);
+  color: var(--color-ink);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -24,6 +24,6 @@
   width: 98%;
   height: 98%;
   z-index: 1;
-  background-color: #fca5a5;
-  border: 3px solid black;
+  background-color: var(--color-caption);
+  border: var(--panel-border) solid var(--color-ink);
 }

--- a/src/components/ComicPanel.css
+++ b/src/components/ComicPanel.css
@@ -3,7 +3,7 @@
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  border: 3px solid black;
+  border: var(--panel-border) solid var(--color-ink);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/ComicTitle.astro
+++ b/src/components/ComicTitle.astro
@@ -66,8 +66,8 @@ const desktopTextY =
         height="86"
         patternTransform="scale(.07)"
       >
-        <rect width="100%" height="86" fill="#f0f" />
-        <circle cx="0" cy="44" r="16" id="title-mob-dot" fill="red" />
+        <rect width="100%" height="86" style="fill: var(--color-halftone-magenta)" />
+        <circle cx="0" cy="44" r="16" id="title-mob-dot" style="fill: var(--color-halftone-red)" />
         <use href="#title-mob-dot" transform="translate(48,0)" />
         <use href="#title-mob-dot" transform="translate(25,-44)" />
         <use href="#title-mob-dot" transform="translate(75,-44)" />
@@ -76,7 +76,7 @@ const desktopTextY =
         <use href="#title-mob-dot" transform="translate(25,42)" />
       </pattern>
       <filter id="title-mob-shadow">
-        <feDropShadow dx="1" dy="1" stdDeviation="0" flood-color="#000000" />
+        <feDropShadow dx="1" dy="1" stdDeviation="0" style="flood-color: var(--color-ink)" />
       </filter>
     </defs>
     {
@@ -89,7 +89,7 @@ const desktopTextY =
           dy={generateJitter(word.length)}
           text-anchor="middle"
           font-size={mobileFontSize}
-          font-family="Bangers, cursive"
+          style="font-family: var(--font-display)"
         >
           {word}
         </text>
@@ -117,8 +117,8 @@ const desktopTextY =
         height="86"
         patternTransform="scale(.07)"
       >
-        <rect width="100%" height="86" fill="#f0f" />
-        <circle cx="0" cy="44" r="16" id="title-desk-dot" fill="red" />
+        <rect width="100%" height="86" style="fill: var(--color-halftone-magenta)" />
+        <circle cx="0" cy="44" r="16" id="title-desk-dot" style="fill: var(--color-halftone-red)" />
         <use href="#title-desk-dot" transform="translate(48,0)" />
         <use href="#title-desk-dot" transform="translate(25,-44)" />
         <use href="#title-desk-dot" transform="translate(75,-44)" />
@@ -127,7 +127,7 @@ const desktopTextY =
         <use href="#title-desk-dot" transform="translate(25,42)" />
       </pattern>
       <filter id="title-desk-shadow">
-        <feDropShadow dx="1" dy="1" stdDeviation="0" flood-color="#000000" />
+        <feDropShadow dx="1" dy="1" stdDeviation="0" style="flood-color: var(--color-ink)" />
       </filter>
     </defs>
     <text
@@ -138,7 +138,7 @@ const desktopTextY =
       dy={generateJitter(displayText.length)}
       text-anchor="middle"
       font-size={desktopFontSize}
-      font-family="Bangers, cursive"
+      style="font-family: var(--font-display)"
     >
       {displayText}
     </text>

--- a/src/components/Credits.astro
+++ b/src/components/Credits.astro
@@ -14,7 +14,7 @@ const team = [
 ];
 ---
 
-<section id="credits" class="bg-gray-200">
+<section id="credits" class="bg-newsprint-shade">
   <div class="headercontainer pb-8 pt-8">
     <h2>Credits</h2>
   </div>

--- a/src/components/Events.css
+++ b/src/components/Events.css
@@ -1,3 +1,3 @@
 .events {
-  @apply flex flex-col place-items-center px-4 py-20 font-sans gap-6 lg:w-2/3;
+  @apply flex flex-col place-items-center px-4 py-20 gap-6 lg:w-2/3;
 }

--- a/src/components/Feature.css
+++ b/src/components/Feature.css
@@ -7,7 +7,7 @@
 }
 
 .feature-text a:not(.button) {
-  @apply text-blue-600 hover:text-blue-800 font-bold;
+  @apply text-accent hover:text-accent-dark font-bold;
 }
 
 .feature-image {

--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -31,7 +31,8 @@
 }
 
 .hero-script {
-  @apply text-center z-10 text-black font-euphoria text-2xl leading-none;
+  font-family: var(--font-script);
+  @apply text-center z-10 text-ink text-2xl leading-none;
 }
 
 .social-icons {
@@ -39,7 +40,7 @@
 }
 
 .icon-link {
-  @apply text-black;
+  @apply text-ink;
 }
 
 .bottomwrapper {

--- a/src/components/Nav.css
+++ b/src/components/Nav.css
@@ -5,7 +5,7 @@
     position: relative;
     margin: 0 0.25rem;
     z-index: 1;
-    @apply text-black font-medium hover:underline;
+    @apply text-ink font-medium hover:underline;
 }
 
 .nav-link:before {
@@ -16,7 +16,7 @@
     right: 0rem;
     bottom: 0.55rem;
     z-index: -1;
-    background-color: white;
+    background-color: var(--color-newsprint);
     clip-path: polygon(
         0% 0%, 7% 10%, 2% 20%, 9% 30%, 3% 40%, 
         8% 50%, 1% 60%, 11% 70%, 3% 80%, 9% 90%, 

--- a/src/components/Privacy.astro
+++ b/src/components/Privacy.astro
@@ -8,7 +8,7 @@ const properties = propertiesJSON;
 <section id="privacy" class="mx-auto mt-12 sm:w-3/4">
   <div class="headercontainer">
     <h1>Privacy Policy</h1>
-    <h2>Important disclosures about how we use your data</h2>
+    <p class="deck">Important disclosures about how we use your data</p>
   </div>
   <div class="contentcontainer">
     <div class="textcontainer">

--- a/src/components/Products.css
+++ b/src/components/Products.css
@@ -1,5 +1,5 @@
 .product-grid {
-    @apply font-sans flex flex-wrap justify-center mt-12;
+    @apply flex flex-wrap justify-center mt-12;
 }
 
 .product-item {
@@ -19,15 +19,15 @@
 }
 
 .product-info-banner {
-    @apply absolute bottom-0 left-0 right-0 bg-black/60 p-2 opacity-0 transition-opacity duration-300;
+    @apply absolute bottom-0 left-0 right-0 bg-ink/70 p-2 opacity-0 transition-opacity duration-300;
 }
 
 .product-title {
-    @apply block text-white font-bold;
+    @apply block text-newsprint font-bold;
 }
 
 .product-description {
-    @apply block text-white text-sm leading-tight;
+    @apply block text-newsprint text-sm leading-tight;
 }
 
 .product-price {

--- a/src/components/ScallopedOval.astro
+++ b/src/components/ScallopedOval.astro
@@ -23,8 +23,8 @@ const path =
   >
     <defs>
       <linearGradient id="scallop-grad" x1="0%" y1="0%" x2="0%" y2="100%">
-        <stop offset="0%" style="stop-color:#FFFFFF;stop-opacity:1" />
-        <stop offset="100%" style="stop-color:#CCCCCC;stop-opacity:1" />
+        <stop offset="0%" style="stop-color: var(--color-newsprint); stop-opacity: 1" />
+        <stop offset="100%" style="stop-color: var(--color-newsprint-deep); stop-opacity: 1" />
       </linearGradient>
     </defs>
     <g transform="translate(-3.0639662,-1.5863552)">

--- a/src/components/SubscribeForm.css
+++ b/src/components/SubscribeForm.css
@@ -1,3 +1,7 @@
+/* Layout is ours; everything below `.formkit-form .formkit-alert` is ConvertKit's
+   own widget CSS, kept verbatim so their script keeps recognising it. Its colour
+   literals are deliberately exempt from the palette in tailwind.config.js. */
+
 .convertkit-form {
   @apply flex flex-col items-center text-center p-4 relative overflow-visible;
 }

--- a/src/components/islands/ContactForm.tsx
+++ b/src/components/islands/ContactForm.tsx
@@ -52,7 +52,7 @@ export default function ContactForm({ formspreeFormId: formId }: Props) {
         {formId ? (
           <ContactFormInner formId={formId} />
         ) : (
-          <p className="text-red-600">
+          <p className="text-alert">
             Error: To use the ContactForm component, supply a formspreeFormId in siteproperties.json.
           </p>
         )}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -37,8 +37,17 @@ import Footer from '../components/Footer.astro';
     width: 100%;
     min-height: 100svh;
     background:
-      radial-gradient(ellipse 80% 50% at 50% -10%, rgba(252, 165, 165, 0.35), transparent 55%),
-      linear-gradient(180deg, #fff7f7 0%, #ffffff 40%, #f8fafc 100%);
+      radial-gradient(
+        ellipse 80% 50% at 50% -10%,
+        color-mix(in srgb, var(--color-caption) 35%, transparent),
+        transparent 55%
+      ),
+      linear-gradient(
+        180deg,
+        color-mix(in srgb, var(--color-caption) 12%, var(--color-newsprint)) 0%,
+        var(--color-newsprint) 40%,
+        var(--color-newsprint-shade) 100%
+      );
   }
 
   .not-found-section {
@@ -53,12 +62,12 @@ import Footer from '../components/Footer.astro';
 
   .not-found-heading {
     margin: 0.35rem 0 0;
-    font-family: 'Bangers', cursive;
+    font-family: var(--font-display);
     font-size: clamp(3.5rem, 12vw, 6rem);
     line-height: 0.9;
     letter-spacing: 0.04em;
-    color: #111;
-    text-shadow: 3px 3px 0 #fca5a5;
+    color: var(--color-ink);
+    text-shadow: 3px 3px 0 var(--color-caption);
     animation: not-found-pop 0.55s cubic-bezier(0.22, 1, 0.36, 1) both;
   }
 
@@ -71,7 +80,7 @@ import Footer from '../components/Footer.astro';
   }
 
   .not-found-panel :global(.comic-panel-container) {
-    box-shadow: 6px 6px 0 #111;
+    box-shadow: var(--panel-shadow);
   }
 
   .not-found-panel :global(.comic-panel-image) {
@@ -84,29 +93,11 @@ import Footer from '../components/Footer.astro';
     animation: not-found-fade-up 0.6s ease 0.28s both;
   }
 
+  /* The ink rule, hard shadow and press animation now come from .button in
+     global.css; the only thing special about this one is that it is the sole
+     action on the page, so it gets to be a size larger. */
   .not-found-home {
-    font-family: 'Bangers', cursive;
     font-size: 1.25rem;
-    letter-spacing: 0.03em;
-    padding: 0.65rem 1.25rem;
-    background: #111;
-    border: 3px solid #111;
-    box-shadow: 4px 4px 0 #fca5a5;
-    transition:
-      transform 0.15s ease,
-      box-shadow 0.15s ease,
-      background-color 0.15s ease;
-  }
-
-  .not-found-home:hover {
-    background: #334155;
-    transform: translate(-2px, -2px);
-    box-shadow: 6px 6px 0 #fca5a5;
-  }
-
-  .not-found-home:active {
-    transform: translate(2px, 2px);
-    box-shadow: 2px 2px 0 #fca5a5;
   }
 
   @keyframes not-found-pop {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,6 +4,42 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ---------------------------------------------------------------------------
+   Design tokens
+
+   The palette and the panel geometry are defined once, in tailwind.config.js.
+   This block republishes them as custom properties so hand-written CSS and
+   inline SVG can reference the same values instead of re-typing literals.
+
+   Use the Tailwind utility (bg-caption, border-ink) where a class will do;
+   use the custom property where it won't.
+   --------------------------------------------------------------------------- */
+:root {
+  --color-ink: theme('colors.ink.DEFAULT');
+  --color-ink-soft: theme('colors.ink.soft');
+  --color-ink-line: theme('colors.ink.line');
+  --color-newsprint: theme('colors.newsprint.DEFAULT');
+  --color-newsprint-shade: theme('colors.newsprint.shade');
+  --color-newsprint-deep: theme('colors.newsprint.deep');
+  --color-halftone-magenta: theme('colors.halftone.magenta');
+  --color-halftone-red: theme('colors.halftone.red');
+  --color-caption: theme('colors.caption.DEFAULT');
+  --color-accent: theme('colors.accent.DEFAULT');
+  --color-accent-dark: theme('colors.accent.dark');
+
+  /* Bangers letters the comic; the sans carries the reading copy; Allura is
+     reserved for the hero's handwritten tagline. */
+  --font-display: theme('fontFamily.bangers');
+  --font-body: theme('fontFamily.sans');
+  --font-script: theme('fontFamily.euphoria');
+
+  /* Panel geometry — the black rule and hard offset shadow that make a
+     rectangle read as a comic panel. Buttons borrow the same vocabulary. */
+  --panel-border: theme('borderWidth.panel');
+  --panel-shadow: theme('boxShadow.panel');
+  --pop-shadow: theme('boxShadow.pop');
+}
+
 html {
   height: 100%;
   box-sizing: border-box;
@@ -13,11 +49,10 @@ html {
 
 html,
 body {
-  font-family: 'Bangers', cursive, -apple-system, system-ui, BlinkMacSystemFont, 'Helvetica Neue',
-    'Helvetica', sans-serif;
+  font-family: var(--font-body);
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
-  @apply bg-white antialiased;
+  @apply bg-newsprint text-ink antialiased;
 }
 
 body {
@@ -36,10 +71,10 @@ a {
   top: 0.5rem;
   z-index: 100;
   padding: 0.5rem 0.75rem;
-  border-radius: 0.25rem;
-  background: #fff;
-  color: #000;
-  font-family: system-ui, sans-serif;
+  background: var(--color-newsprint);
+  color: var(--color-ink);
+  border: var(--panel-border) solid var(--color-ink);
+  font-family: var(--font-body);
   font-size: 1rem;
   text-decoration: underline;
   transform: translateY(-150%);
@@ -50,7 +85,7 @@ a {
 }
 
 a:not(.button) {
-  @apply text-black underline hover:text-gray-600;
+  @apply text-ink underline hover:text-accent;
 }
 
 .headercontainer {
@@ -61,32 +96,48 @@ section {
   @apply text-center w-full;
 }
 
-h1 {
-  @apply text-4xl font-bold font-bangers;
+/* ---------------------------------------------------------------------------
+   The type rule: Bangers letters the display type — headings, narration, nav.
+   The sans carries anything you actually sit down and read.
+   --------------------------------------------------------------------------- */
+h1,
+h2,
+h3 {
+  font-family: var(--font-display);
+  @apply font-bold tracking-wide;
 }
 
-.headercontainer > h2:only-child {
-  @apply text-4xl font-bold font-bangers;
-}
-
+h1,
 h2 {
-  @apply text-2xl font-bold font-sans;
+  @apply text-4xl;
 }
 
 h3 {
-  @apply my-4 text-xl font-bold font-sans;
+  @apply my-4 text-2xl;
+}
+
+/* A subtitle under a page title: sans, because it is read rather than shouted. */
+.deck {
+  font-family: var(--font-body);
+  @apply text-lg text-ink-soft;
 }
 
 p {
-  @apply py-4 text-lg font-sans;
+  @apply py-4 text-lg;
 }
 
 button:not(.button) {
-  @apply my-4 text-base font-sans;
+  @apply my-4 text-base;
 }
 
-input, textarea {
-  @apply p-2 text-base font-sans w-full border-gray-200 border-2 placeholder:text-gray-500;
+input,
+textarea {
+  @apply p-2 text-base w-full border-ink-line border-2 placeholder:text-ink-soft;
+}
+
+input:focus,
+textarea:focus {
+  @apply border-ink;
 }
 
 ol, ul {
@@ -94,12 +145,46 @@ ol, ul {
   padding-left: 1em;
 }
 
+/* ---------------------------------------------------------------------------
+   Buttons borrow the panel's vocabulary: a heavy ink rule and a hard,
+   un-blurred shadow that the button slides into when you press it.
+   --------------------------------------------------------------------------- */
 .button {
-  @apply inline-block p-2 m-0 border-0 bg-slate-600 hover:bg-slate-800 text-white hover:text-white rounded-md no-underline cursor-pointer text-base font-sans;
+  font-family: var(--font-display);
+  @apply inline-block m-0 px-5 py-2 text-lg tracking-wide no-underline cursor-pointer;
+  @apply bg-accent text-newsprint hover:text-newsprint;
+  border: var(--panel-border) solid var(--color-ink);
+  box-shadow: var(--pop-shadow);
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.button:hover:not(:disabled) {
+  @apply bg-accent-dark;
+  transform: translate(-2px, -2px);
+  box-shadow: var(--panel-shadow);
+}
+
+.button:active:not(:disabled) {
+  transform: translate(2px, 2px);
+  box-shadow: 2px 2px 0 var(--color-ink);
 }
 
 .button:disabled {
   @apply opacity-50 cursor-not-allowed;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .button {
+    transition: none;
+  }
+
+  .button:hover:not(:disabled),
+  .button:active:not(:disabled) {
+    transform: none;
+  }
 }
 
 .animated {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,16 +1,65 @@
+/**
+ * The palette. This is the single source of truth for colour on the site:
+ * this file turns it into utilities (`bg-caption`, `text-accent`,
+ * `border-ink`), and `src/styles/global.css` republishes it as custom
+ * properties (`--color-ink`, …) for hand-written CSS and inline SVG.
+ *
+ * Rule of thumb: if you are about to type a hex code anywhere else in this
+ * repo, add it here instead and reference it by name.
+ */
+const palette = {
+  /** Ink — panel rules, lettering, hard drop shadows. Everything is drawn in it. */
+  ink: {
+    DEFAULT: '#111111',
+    soft: '#4b5563', // secondary copy, placeholders
+    line: '#d6d1c4', // hairlines and input borders, tinted warm like newsprint
+  },
+  /** Newsprint — the page itself and the bands that break it up. */
+  newsprint: {
+    DEFAULT: '#ffffff',
+    shade: '#efece4', // alternating section ground
+    deep: '#cfcabb', // the shaded foot of the scalloped oval
+  },
+  /** Halftone — the two-colour dot screen behind the logotype. */
+  halftone: {
+    magenta: '#ff00ff',
+    red: '#ff0000',
+  },
+  /** Caption — narration-box fill. The colour the story is told in. */
+  caption: {
+    DEFAULT: '#fca5a5',
+    edge: '#f87171',
+  },
+  /** Accent — the one hue that means "act on this". Buttons and inline CTAs. */
+  accent: {
+    DEFAULT: '#2563eb',
+    dark: '#1e40af',
+  },
+  /** Alert — validation and error copy only. */
+  alert: '#dc2626',
+};
+
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: ["./src/**/*.{astro,html,js,ts,jsx,tsx}"],
+  content: ['./src/**/*.{astro,html,js,ts,jsx,tsx}'],
   theme: {
     extend: {
+      colors: palette,
       fontFamily: {
-        'bangers': ['Bangers', 'cursive'],
-        'euphoria': ['Allura', 'cursive'],
+        bangers: ['Bangers', 'cursive'],
+        euphoria: ['Allura', 'cursive'],
+      },
+      borderWidth: {
+        panel: '3px',
+      },
+      boxShadow: {
+        /** The hard, offset, un-blurred shadow that makes a rectangle read as a panel. */
+        panel: `6px 6px 0 ${palette.ink.DEFAULT}`,
+        pop: `4px 4px 0 ${palette.ink.DEFAULT}`,
       },
       maxWidth: {
-        'custom': '300px',
-      }
-    }
-  }
-}
-
+        custom: '300px',
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Summary
Centralize all design decisions (colors, fonts, panel geometry) into a single source of truth in `tailwind.config.js`, then republish them as CSS custom properties for use in hand-written CSS and inline SVG. This eliminates color and style literals scattered throughout the codebase and makes the design system maintainable and consistent.

## Key Changes

- **Design token definition** (`tailwind.config.js`): Created a `palette` object defining all colors (ink, newsprint, halftone, caption, accent, alert) and extended the theme with font families, border widths, and box shadows for panel geometry
- **CSS custom properties** (`src/styles/global.css`): Added `:root` block republishing all design tokens as `--color-*`, `--font-*`, and `--panel-*` custom properties with `theme()` function references
- **Global styles refactor** (`src/styles/global.css`): 
  - Updated typography hierarchy to use custom properties and clarified font usage rules (Bangers for display, sans for body, Allura for script)
  - Replaced hardcoded colors and fonts throughout with custom properties
  - Enhanced button styling with panel vocabulary (ink border, hard shadow, press animation) and reduced-motion support
  - Updated form inputs to use the design palette
- **Component updates**: Replaced all hardcoded hex codes, color names, and font literals with custom properties or Tailwind utilities across:
  - `ComicTitle.astro`, `ComicNarration.css`, `ComicPanel.css` (SVG halftone patterns, narration boxes)
  - `Hero.css`, `Nav.css`, `Feature.css` (typography and link colors)
  - `Products.css`, `Credits.astro`, `Events.css` (background and text colors)
  - `404.astro` (gradient backgrounds using `color-mix()`)
  - `ContactForm.tsx` (alert color)
- **Documentation** (`AGENTS.md`): Added design tokens section explaining the pattern and preference for utilities over custom properties

## Implementation Details

- Used Tailwind's `theme()` function in CSS to maintain single source of truth
- Established clear guidance: prefer Tailwind utilities (`.bg-caption`, `.text-ink`) where classes apply; use custom properties where they don't (SVG `style` attributes, inline styles)
- Panel geometry (3px border, 6px shadow) now consistently applied to both panels and buttons
- Preserved ConvertKit widget CSS as-is with explanatory comment
- All color literals replaced; no magic numbers remain in component files

https://claude.ai/code/session_01HhZ7L3xoD33b58LehqrrWK