### PR TITLE
Establish design token system for consistent theming

### DIFF
--- a/src/components/ComicNarration.css
+++ b/src/components/ComicNarration.css
@@ -2,8 +2,8 @@
   position: relative;
   width: 100%;
   height: 100%;
-  font-family: 'Bangers', cursive;
-  color: black;
+  font-family: var(--font-display);
+  color: var(--ink);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -24,6 +24,6 @@
   width: 98%;
   height: 98%;
   z-index: 1;
-  background-color: #fca5a5;
-  border: 3px solid black;
+  background-color: var(--caption-pink);
+  border: var(--border-ink);
 }

--- a/src/components/ComicPanel.css
+++ b/src/components/ComicPanel.css
@@ -3,7 +3,7 @@
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  border: 3px solid black;
+  border: var(--border-ink);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/ComicTitle.astro
+++ b/src/components/ComicTitle.astro
@@ -66,8 +66,8 @@ const desktopTextY =
         height="86"
         patternTransform="scale(.07)"
       >
-        <rect width="100%" height="86" fill="#f0f" />
-        <circle cx="0" cy="44" r="16" id="title-mob-dot" fill="red" />
+        <rect width="100%" height="86" style="fill: var(--halftone-magenta)" />
+        <circle cx="0" cy="44" r="16" id="title-mob-dot" style="fill: var(--halftone-red)" />
         <use href="#title-mob-dot" transform="translate(48,0)" />
         <use href="#title-mob-dot" transform="translate(25,-44)" />
         <use href="#title-mob-dot" transform="translate(75,-44)" />
@@ -76,7 +76,7 @@ const desktopTextY =
         <use href="#title-mob-dot" transform="translate(25,42)" />
       </pattern>
       <filter id="title-mob-shadow">
-        <feDropShadow dx="1" dy="1" stdDeviation="0" flood-color="#000000" />
+        <feDropShadow dx="1" dy="1" stdDeviation="0" style="flood-color: var(--ink)" />
       </filter>
     </defs>
     {
@@ -89,7 +89,7 @@ const desktopTextY =
           dy={generateJitter(word.length)}
           text-anchor="middle"
           font-size={mobileFontSize}
-          font-family="Bangers, cursive"
+          style="font-family: var(--font-display)"
         >
           {word}
         </text>
@@ -117,8 +117,8 @@ const desktopTextY =
         height="86"
         patternTransform="scale(.07)"
       >
-        <rect width="100%" height="86" fill="#f0f" />
-        <circle cx="0" cy="44" r="16" id="title-desk-dot" fill="red" />
+        <rect width="100%" height="86" style="fill: var(--halftone-magenta)" />
+        <circle cx="0" cy="44" r="16" id="title-desk-dot" style="fill: var(--halftone-red)" />
         <use href="#title-desk-dot" transform="translate(48,0)" />
         <use href="#title-desk-dot" transform="translate(25,-44)" />
         <use href="#title-desk-dot" transform="translate(75,-44)" />
@@ -127,7 +127,7 @@ const desktopTextY =
         <use href="#title-desk-dot" transform="translate(25,42)" />
       </pattern>
       <filter id="title-desk-shadow">
-        <feDropShadow dx="1" dy="1" stdDeviation="0" flood-color="#000000" />
+        <feDropShadow dx="1" dy="1" stdDeviation="0" style="flood-color: var(--ink)" />
       </filter>
     </defs>
     <text
@@ -138,7 +138,7 @@ const desktopTextY =
       dy={generateJitter(displayText.length)}
       text-anchor="middle"
       font-size={desktopFontSize}
-      font-family="Bangers, cursive"
+      style="font-family: var(--font-display)"
     >
       {displayText}
     </text>

--- a/src/components/Credits.astro
+++ b/src/components/Credits.astro
@@ -14,7 +14,7 @@ const team = [
 ];
 ---
 
-<section id="credits" class="bg-gray-200">
+<section id="credits" class="bg-newsprint-shade">
   <div class="headercontainer pb-8 pt-8">
     <h2>Credits</h2>
   </div>

--- a/src/components/Credits.css
+++ b/src/components/Credits.css
@@ -3,7 +3,7 @@
 }
 
 .panelcontainer {
-    @apply w-full text-center font-bangers py-6 col-span-2;
+    @apply w-full text-center font-display py-6 col-span-2;
 }
 
 /* Center the second row: two col-span-2 panels in cols 4–7 of a 10-column grid. */

--- a/src/components/Feature.css
+++ b/src/components/Feature.css
@@ -7,7 +7,7 @@
 }
 
 .feature-text a:not(.button) {
-  @apply text-blue-600 hover:text-blue-800 font-bold;
+  @apply text-accent hover:text-accent-dark font-bold;
 }
 
 .feature-image {

--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -2,6 +2,6 @@
 
 .footercontents {@apply justify-center mx-auto w-full max-w-screen-xl p-4 py-6 lg:py-8}
 
-.copyrighttext {@apply text-sm text-center font-bangers}
+.copyrighttext {@apply text-sm text-center font-display}
 
 .copyrighttext a {@apply hover:underline}

--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -31,7 +31,7 @@
 }
 
 .hero-script {
-  @apply text-center z-10 text-black font-euphoria text-2xl leading-none;
+  @apply text-center z-10 text-ink font-script text-2xl leading-none;
 }
 
 .social-icons {
@@ -39,7 +39,7 @@
 }
 
 .icon-link {
-  @apply text-black;
+  @apply text-ink;
 }
 
 .bottomwrapper {

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -3,7 +3,7 @@ import './Nav.css';
 import { sectionNavLinks } from '../data/navLinks';
 ---
 
-<div class="space-x-6 inline-flex flex-wrap justify-center font-bangers">
+<div class="space-x-6 inline-flex flex-wrap justify-center font-display">
   {sectionNavLinks.map(({ href, label }) => (
     <a href={href} class="nav-link">{label}</a>
   ))}

--- a/src/components/Nav.css
+++ b/src/components/Nav.css
@@ -5,7 +5,7 @@
     position: relative;
     margin: 0 0.25rem;
     z-index: 1;
-    @apply text-black font-medium hover:underline;
+    @apply text-ink font-display font-medium hover:underline;
 }
 
 .nav-link:before {
@@ -16,7 +16,7 @@
     right: 0rem;
     bottom: 0.55rem;
     z-index: -1;
-    background-color: white;
+    background-color: var(--newsprint);
     clip-path: polygon(
         0% 0%, 7% 10%, 2% 20%, 9% 30%, 3% 40%, 
         8% 50%, 1% 60%, 11% 70%, 3% 80%, 9% 90%, 

--- a/src/components/Products.css
+++ b/src/components/Products.css
@@ -19,15 +19,15 @@
 }
 
 .product-info-banner {
-    @apply absolute bottom-0 left-0 right-0 bg-black/60 p-2 opacity-0 transition-opacity duration-300;
+    @apply absolute bottom-0 left-0 right-0 bg-ink/60 p-2 opacity-0 transition-opacity duration-300;
 }
 
 .product-title {
-    @apply block text-white font-bold;
+    @apply block text-newsprint font-bold;
 }
 
 .product-description {
-    @apply block text-white text-sm leading-tight;
+    @apply block text-newsprint text-sm leading-tight;
 }
 
 .product-price {

--- a/src/components/ScallopedOval.astro
+++ b/src/components/ScallopedOval.astro
@@ -23,8 +23,8 @@ const path =
   >
     <defs>
       <linearGradient id="scallop-grad" x1="0%" y1="0%" x2="0%" y2="100%">
-        <stop offset="0%" style="stop-color:#FFFFFF;stop-opacity:1" />
-        <stop offset="100%" style="stop-color:#CCCCCC;stop-opacity:1" />
+        <stop offset="0%" style="stop-color: var(--newsprint); stop-opacity: 1" />
+        <stop offset="100%" style="stop-color: var(--newsprint-shade); stop-opacity: 1" />
       </linearGradient>
     </defs>
     <g transform="translate(-3.0639662,-1.5863552)">

--- a/src/components/SimpleNav.css
+++ b/src/components/SimpleNav.css
@@ -1,3 +1,3 @@
-.simplenavlinks {@apply flex flex-wrap pt-4 justify-center text-2xl font-bangers}
+.simplenavlinks {@apply flex flex-wrap pt-4 justify-center text-2xl font-display}
 
 .simplenavlink {@apply px-4 no-underline hover:underline}

--- a/src/components/SubscribeForm.css
+++ b/src/components/SubscribeForm.css
@@ -18,6 +18,11 @@
   @apply w-full lg:w-auto;
 }
 
+/*
+ * Everything below is ConvertKit's own form styling, kept close to what their
+ * embed ships so the widget keeps working when they update it. Its status
+ * colors are deliberately outside the site palette — do not tokenize them.
+ */
 .formkit-form .formkit-alert {
   background: #f9fafb;
   border: 1px solid #e3e3e3;

--- a/src/components/islands/ContactForm.tsx
+++ b/src/components/islands/ContactForm.tsx
@@ -52,7 +52,7 @@ export default function ContactForm({ formspreeFormId: formId }: Props) {
         {formId ? (
           <ContactFormInner formId={formId} />
         ) : (
-          <p className="text-red-600">
+          <p className="text-alert">
             Error: To use the ContactForm component, supply a formspreeFormId in siteproperties.json.
           </p>
         )}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -37,8 +37,17 @@ import Footer from '../components/Footer.astro';
     width: 100%;
     min-height: 100svh;
     background:
-      radial-gradient(ellipse 80% 50% at 50% -10%, rgba(252, 165, 165, 0.35), transparent 55%),
-      linear-gradient(180deg, #fff7f7 0%, #ffffff 40%, #f8fafc 100%);
+      radial-gradient(
+        ellipse 80% 50% at 50% -10%,
+        rgb(var(--caption-pink-rgb) / 0.35),
+        transparent 55%
+      ),
+      linear-gradient(
+        180deg,
+        rgb(var(--caption-pink-rgb) / 0.09) 0%,
+        var(--newsprint) 40%,
+        rgb(var(--newsprint-shade-rgb) / 0.25) 100%
+      );
   }
 
   .not-found-section {
@@ -53,12 +62,12 @@ import Footer from '../components/Footer.astro';
 
   .not-found-heading {
     margin: 0.35rem 0 0;
-    font-family: 'Bangers', cursive;
+    font-family: var(--font-display);
     font-size: clamp(3.5rem, 12vw, 6rem);
     line-height: 0.9;
     letter-spacing: 0.04em;
-    color: #111;
-    text-shadow: 3px 3px 0 #fca5a5;
+    color: var(--ink);
+    text-shadow: 3px 3px 0 var(--caption-pink);
     animation: not-found-pop 0.55s cubic-bezier(0.22, 1, 0.36, 1) both;
   }
 
@@ -71,7 +80,7 @@ import Footer from '../components/Footer.astro';
   }
 
   .not-found-panel :global(.comic-panel-container) {
-    box-shadow: 6px 6px 0 #111;
+    box-shadow: 6px 6px 0 var(--ink);
   }
 
   .not-found-panel :global(.comic-panel-image) {
@@ -85,13 +94,13 @@ import Footer from '../components/Footer.astro';
   }
 
   .not-found-home {
-    font-family: 'Bangers', cursive;
+    font-family: var(--font-display);
     font-size: 1.25rem;
     letter-spacing: 0.03em;
     padding: 0.65rem 1.25rem;
-    background: #111;
-    border: 3px solid #111;
-    box-shadow: 4px 4px 0 #fca5a5;
+    background: var(--ink);
+    border: var(--border-ink);
+    box-shadow: 4px 4px 0 var(--caption-pink);
     transition:
       transform 0.15s ease,
       box-shadow 0.15s ease,
@@ -99,14 +108,14 @@ import Footer from '../components/Footer.astro';
   }
 
   .not-found-home:hover {
-    background: #334155;
+    background: var(--accent);
     transform: translate(-2px, -2px);
-    box-shadow: 6px 6px 0 #fca5a5;
+    box-shadow: 6px 6px 0 var(--caption-pink);
   }
 
   .not-found-home:active {
     transform: translate(2px, 2px);
-    box-shadow: 2px 2px 0 #fca5a5;
+    box-shadow: 2px 2px 0 var(--caption-pink);
   }
 
   @keyframes not-found-pop {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,6 +4,59 @@
 @tailwind components;
 @tailwind utilities;
 
+/*
+ * Design tokens — the single source of truth for color and type on this site.
+ *
+ * Each color is declared once as an `-rgb` channel triplet. tailwind.config.js
+ * wraps those triplets in `rgb(... / <alpha-value>)` to build the theme, so the
+ * Tailwind class (`bg-caption-pink`) and the plain-CSS var (`var(--caption-pink)`)
+ * always resolve to the same value. Hand-written CSS and inline SVG use the
+ * paired non-`-rgb` var; anything that needs transparency composes the triplet
+ * directly, e.g. `rgb(var(--caption-pink-rgb) / 0.35)`.
+ */
+:root {
+  /* Line work and body text. */
+  --ink-rgb: 0 0 0;
+  --ink-muted-rgb: 75 85 99;
+  /* Page stock. */
+  --newsprint-rgb: 255 255 255;
+  --newsprint-shade-rgb: 229 231 235;
+  /* Process colors, used by the halftone title fill. */
+  --halftone-magenta-rgb: 255 0 255;
+  --halftone-red-rgb: 255 0 0;
+  /* Narration boxes. */
+  --caption-pink-rgb: 252 165 165;
+  /* The one accent: buttons and in-copy links. */
+  --accent-rgb: 71 85 105;
+  --accent-dark-rgb: 30 41 59;
+  /* Form validation copy. */
+  --alert-rgb: 220 38 38;
+
+  --ink: rgb(var(--ink-rgb));
+  --ink-muted: rgb(var(--ink-muted-rgb));
+  --newsprint: rgb(var(--newsprint-rgb));
+  --newsprint-shade: rgb(var(--newsprint-shade-rgb));
+  --halftone-magenta: rgb(var(--halftone-magenta-rgb));
+  --halftone-red: rgb(var(--halftone-red-rgb));
+  --caption-pink: rgb(var(--caption-pink-rgb));
+  --accent: rgb(var(--accent-rgb));
+  --accent-dark: rgb(var(--accent-dark-rgb));
+  --alert: rgb(var(--alert-rgb));
+
+  /*
+   * Type: Bangers for display (title, headings, narration, nav), Allura for the
+   * one bit of script in the hero, a system sans for everything you actually
+   * read. Body copy inherits `--font-sans`; display type opts in explicitly.
+   */
+  --font-display: 'Bangers', cursive;
+  --font-script: 'Allura', cursive;
+  --font-sans: -apple-system, system-ui, BlinkMacSystemFont, 'Helvetica Neue', 'Helvetica',
+    sans-serif;
+
+  /* Weight of the panel and narration border, so the comic keeps one line width. */
+  --border-ink: 3px solid var(--ink);
+}
+
 html {
   height: 100%;
   box-sizing: border-box;
@@ -13,11 +66,10 @@ html {
 
 html,
 body {
-  font-family: 'Bangers', cursive, -apple-system, system-ui, BlinkMacSystemFont, 'Helvetica Neue',
-    'Helvetica', sans-serif;
+  font-family: var(--font-sans);
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
-  @apply bg-white antialiased;
+  @apply bg-newsprint antialiased;
 }
 
 body {
@@ -27,7 +79,7 @@ body {
 }
 
 a {
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  -webkit-tap-highlight-color: rgb(var(--ink-rgb) / 0);
 }
 
 .skip-link {
@@ -37,9 +89,9 @@ a {
   z-index: 100;
   padding: 0.5rem 0.75rem;
   border-radius: 0.25rem;
-  background: #fff;
-  color: #000;
-  font-family: system-ui, sans-serif;
+  background: var(--newsprint);
+  color: var(--ink);
+  font-family: var(--font-sans);
   font-size: 1rem;
   text-decoration: underline;
   transform: translateY(-150%);
@@ -50,7 +102,7 @@ a {
 }
 
 a:not(.button) {
-  @apply text-black underline hover:text-gray-600;
+  @apply text-ink underline hover:text-ink-muted;
 }
 
 .headercontainer {
@@ -61,32 +113,34 @@ section {
   @apply text-center w-full;
 }
 
+/* Headings are display type — that is the rule, no exceptions. */
 h1 {
-  @apply text-4xl font-bold font-bangers;
+  @apply text-4xl font-bold font-display;
 }
 
 .headercontainer > h2:only-child {
-  @apply text-4xl font-bold font-bangers;
+  @apply text-4xl font-bold font-display;
 }
 
 h2 {
-  @apply text-2xl font-bold font-sans;
+  @apply text-2xl font-bold font-display;
 }
 
 h3 {
-  @apply my-4 text-xl font-bold font-sans;
+  @apply my-4 text-xl font-bold font-display;
 }
 
+/* Body copy and UI inherit --font-sans from <body>; no per-element opt-in. */
 p {
-  @apply py-4 text-lg font-sans;
+  @apply py-4 text-lg;
 }
 
 button:not(.button) {
-  @apply my-4 text-base font-sans;
+  @apply my-4 text-base;
 }
 
 input, textarea {
-  @apply p-2 text-base font-sans w-full border-gray-200 border-2 placeholder:text-gray-500;
+  @apply p-2 text-base w-full border-newsprint-shade border-2 placeholder:text-ink-muted;
 }
 
 ol, ul {
@@ -95,7 +149,7 @@ ol, ul {
 }
 
 .button {
-  @apply inline-block p-2 m-0 border-0 bg-slate-600 hover:bg-slate-800 text-white hover:text-white rounded-md no-underline cursor-pointer text-base font-sans;
+  @apply inline-block p-2 m-0 border-0 bg-accent hover:bg-accent-dark text-newsprint hover:text-newsprint rounded-md no-underline cursor-pointer text-base;
 }
 
 .button:disabled {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,41 @@
 /** @type {import('tailwindcss').Config} */
+
+// The palette and type stacks are declared as custom properties in
+// src/styles/global.css so hand-written CSS and inline SVG can reach them too.
+// This file only maps those properties onto Tailwind's theme, so a value is
+// defined in exactly one place. Colors resolve through the `-rgb` channel
+// triplets, which is what keeps opacity modifiers (e.g. `bg-ink/60`) working.
+const withAlpha = (channels) => `rgb(var(${channels}) / <alpha-value>)`;
+
 export default {
   content: ["./src/**/*.{astro,html,js,ts,jsx,tsx}"],
   theme: {
     extend: {
+      colors: {
+        // Line work and body text.
+        ink: withAlpha('--ink-rgb'),
+        'ink-muted': withAlpha('--ink-muted-rgb'),
+        // Page stock.
+        newsprint: withAlpha('--newsprint-rgb'),
+        'newsprint-shade': withAlpha('--newsprint-shade-rgb'),
+        // Process colors, used by the halftone title fill.
+        'halftone-magenta': withAlpha('--halftone-magenta-rgb'),
+        'halftone-red': withAlpha('--halftone-red-rgb'),
+        // Narration boxes.
+        'caption-pink': withAlpha('--caption-pink-rgb'),
+        // The one accent: buttons and in-copy links.
+        accent: withAlpha('--accent-rgb'),
+        'accent-dark': withAlpha('--accent-dark-rgb'),
+        // Form validation copy.
+        alert: withAlpha('--alert-rgb'),
+      },
       fontFamily: {
-        'bangers': ['Bangers', 'cursive'],
-        'euphoria': ['Allura', 'cursive'],
+        // `display` is Bangers (title, headings, narration), `script` is Allura
+        // (the hero tagline), `sans` is body copy and UI. The stacks themselves
+        // live in global.css alongside the palette.
+        display: 'var(--font-display)',
+        script: 'var(--font-script)',
+        sans: 'var(--font-sans)',
       },
       maxWidth: {
         'custom': '300px',
@@ -13,4 +43,3 @@ export default {
     }
   }
 }
-


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive design token system as the single source of truth for colors and typography across the site. All hardcoded color values and font declarations are replaced with CSS custom properties, enabling consistent theming and easier maintenance.

## Key Changes

- **Design tokens in global.css**: Established a complete palette of CSS custom properties (colors as `-rgb` channel triplets for opacity support, plus typography stacks) with detailed documentation
- **Tailwind integration**: Updated `tailwind.config.js` to map design tokens onto Tailwind's theme, ensuring Tailwind classes and plain CSS variables always resolve to the same values
- **Global styles refactor**: Replaced all hardcoded colors (`#000`, `#fff`, `#fca5a5`, etc.) and font families with token references throughout `global.css`
- **Component updates**: Migrated all component CSS files to use design tokens:
  - `ComicTitle.astro`: SVG fill and font-family attributes now use tokens
  - `ComicNarration.css`, `ComicPanel.css`: Border and color tokens
  - `Hero.css`, `Nav.css`, `Nav.astro`: Typography and color tokens
  - `Products.css`, `Feature.css`, `Footer.css`: Color and font tokens
  - `ScallopedOval.astro`: Gradient stop colors use tokens
  - `Credits.astro`, `Credits.css`: Background and font tokens
  - `ContactForm.tsx`: Alert color token
- **404 page styling**: Refactored gradient backgrounds to use design tokens with proper opacity composition
- **SubscribeForm.css**: Added clarifying comment about ConvertKit's external styling

## Implementation Details

- Colors use RGB channel triplets (e.g., `--ink-rgb: 0 0 0`) wrapped in `rgb(var(...) / <alpha-value>)` to support Tailwind's opacity modifiers
- Typography stacks defined once in global.css and referenced via custom properties in both CSS and Tailwind config
- Display type (Bangers) explicitly applied to headings, narration, and navigation; body copy inherits sans-serif from `<body>`
- Border width standardized via `--border-ink` token for consistent line weight across panels and narration boxes

https://claude.ai/code/session_01G6EMg3uu3rEeRHGtoeFtfm