### PR TITLE
Bump intern titles and pull latest Substack posts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Commit and push changes to repository
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: 'Automated product feed update'
+          commit_message: 'Automated feed update'
 
       - name: Get domain
         id: get-domain

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "astro dev",
     "fetchproducts": "bun scripts/fetchproductfeed.mjs",
-    "build": "bun run fetchproducts && astro build",
+    "fetchsubstack": "bun scripts/fetchsubstack.mjs",
+    "build": "bun run fetchproducts && bun run fetchsubstack && astro build",
     "preview": "astro preview",
     "lint": "eslint src --report-unused-disable-directives --max-warnings 0",
     "typecheck": "astro check",

--- a/scripts/fetchsubstack.mjs
+++ b/scripts/fetchsubstack.mjs
@@ -1,0 +1,62 @@
+import fs from 'fs';
+import { extract } from '@extractus/feed-extractor'
+
+const sitedata = JSON.parse(fs.readFileSync('src/customizations/siteproperties.json', 'utf8'));
+const feedUrl = sitedata.substackUrl + '/feed';
+
+function enclosureUrl(enclosure) {
+  if (!enclosure) return undefined;
+  const items = Array.isArray(enclosure) ? enclosure : [enclosure];
+  const image = items.find((entry) => typeof entry?.url === 'string') ?? items[0];
+  return typeof image?.url === 'string' ? image.url : undefined;
+}
+
+function slimItem(item) {
+  const image = enclosureUrl(item.enclosure);
+  return {
+    title: item.title,
+    description: item.description ?? '',
+    link: item.link,
+    pubDate: item.pubDate,
+    ...(image ? { image } : {}),
+  };
+}
+
+async function fetchSubstackFeed() {
+  try {
+    const feedData = await extract(feedUrl, {
+      useISODateFormat: false,
+      normalization: false,
+    });
+
+    if (!feedData || typeof feedData !== 'object') {
+      throw new Error('Invalid Substack feed data');
+    }
+
+    const rawItems = feedData.item
+      ? Array.isArray(feedData.item)
+        ? feedData.item
+        : [feedData.item]
+      : [];
+    const items = rawItems.map(slimItem).filter((item) => item.title && item.link);
+
+    if (items.length === 0) {
+      throw new Error('Substack feed contained no items');
+    }
+
+    const slimFeed = {
+      title: feedData.title,
+      description: feedData.description,
+      link: feedData.link ?? sitedata.substackUrl,
+      item: items,
+    };
+
+    fs.writeFileSync('src/customizations/substackfeed.json', JSON.stringify(slimFeed, null, 2));
+
+    console.log('Substack feed saved successfully!');
+  } catch (error) {
+    console.error('Error fetching Substack feed:', error);
+  }
+}
+
+fetchSubstackFeed();

--- a/src/components/Credits.astro
+++ b/src/components/Credits.astro
@@ -9,8 +9,8 @@ const team = [
   { name: 'Neil Carlson', role: 'Partner', image: 'images/team/Neil.jpg', alt: 'Portrait of Neil Carlson, Partner' },
   { name: 'Cliff Bentley', role: 'Partner', image: 'images/team/Cliff.jpg', alt: 'Portrait of Cliff Bentley, Partner' },
   { name: 'Jenny Xu', role: 'Intern', image: 'images/team/Jenny.jpg', alt: 'Portrait of Jenny Xu, Intern' },
-  { name: 'Sravan Parakala', role: 'Intern', image: 'images/team/Sravan.jpg', alt: 'Portrait of Sravan Parakala, Intern' },
-  { name: 'Rafi Khan', role: 'Intern', image: 'images/team/Rafi.jpg', alt: 'Portrait of Rafiuzzaman Khan, Intern' },
+  { name: 'Sravan Parakala', role: 'Junior Developer', image: 'images/team/Sravan.jpg', alt: 'Portrait of Sravan Parakala, Junior Developer' },
+  { name: 'Rafi Khan', role: 'Junior Developer', image: 'images/team/Rafi.jpg', alt: 'Portrait of Rafiuzzaman Khan, Junior Developer' },
 ];
 ---
 

--- a/src/components/Credits.astro
+++ b/src/components/Credits.astro
@@ -9,8 +9,8 @@ const team = [
   { name: 'Neil Carlson', role: 'Partner', image: 'images/team/Neil.jpg', alt: 'Portrait of Neil Carlson, Partner' },
   { name: 'Cliff Bentley', role: 'Partner', image: 'images/team/Cliff.jpg', alt: 'Portrait of Cliff Bentley, Partner' },
   { name: 'Jenny Xu', role: 'Intern', image: 'images/team/Jenny.jpg', alt: 'Portrait of Jenny Xu, Intern' },
-  { name: 'Sravan Parakala', role: 'Junior Developer', image: 'images/team/Sravan.jpg', alt: 'Portrait of Sravan Parakala, Junior Developer' },
-  { name: 'Rafi Khan', role: 'Junior Developer', image: 'images/team/Rafi.jpg', alt: 'Portrait of Rafiuzzaman Khan, Junior Developer' },
+  { name: 'Sravan Parakala', role: 'Junior Software Engineer', image: 'images/team/Sravan.jpg', alt: 'Portrait of Sravan Parakala, Junior Software Engineer' },
+  { name: 'Rafi Khan', role: 'Junior Software Engineer', image: 'images/team/Rafi.jpg', alt: 'Portrait of Rafiuzzaman Khan, Junior Software Engineer' },
 ];
 ---
 

--- a/src/components/Newsletter.astro
+++ b/src/components/Newsletter.astro
@@ -1,0 +1,73 @@
+---
+import './Newsletter.css';
+import ComicPanel from './ComicPanel.astro';
+import siteProperties from '../customizations/siteproperties.json';
+import substackFeedJSON from '../customizations/substackfeed.json';
+import type SubstackFeed from '../types/substackfeed';
+import type { SubstackItem } from '../types/substackfeed';
+
+const substackFeed: SubstackFeed = substackFeedJSON;
+const FALLBACK_IMAGE = 'images/AIart.jpg';
+const POSTS_TO_SHOW = 3;
+
+const items: SubstackItem[] = substackFeed?.item
+  ? Array.isArray(substackFeed.item)
+    ? substackFeed.item
+    : [substackFeed.item]
+  : [];
+
+const posts = items.slice(0, POSTS_TO_SHOW);
+const archiveUrl = substackFeed.link || siteProperties.substackUrl;
+
+function formatDate(pubDate: string): string {
+  const date = new Date(pubDate);
+  if (Number.isNaN(date.getTime())) return pubDate;
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function dateTime(pubDate: string): string | undefined {
+  const date = new Date(pubDate);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+---
+
+{
+  posts.length > 0 && (
+    <section class="newsletter" id="newsletter">
+      <div class="headercontainer">
+        <h2>From the Guide</h2>
+      </div>
+      <div class="newsletter-grid">
+        {posts.map((post) => (
+          <a
+            href={post.link}
+            class="newsletter-item"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <div class="newsletter-panel">
+              <ComicPanel
+                backgroundImage={post.image ?? FALLBACK_IMAGE}
+                altText={post.title}
+              />
+            </div>
+            <span class="newsletter-title">{post.title}</span>
+            {post.pubDate && (
+              <time class="newsletter-date" datetime={dateTime(post.pubDate)}>
+                {formatDate(post.pubDate)}
+              </time>
+            )}
+            {post.description && <span class="newsletter-subtitle">{post.description}</span>}
+          </a>
+        ))}
+      </div>
+      <a href={archiveUrl} class="button" target="_blank" rel="noopener noreferrer">
+        Read the newsletter
+      </a>
+    </section>
+  )
+}

--- a/src/components/Newsletter.css
+++ b/src/components/Newsletter.css
@@ -1,0 +1,37 @@
+.newsletter {
+  @apply flex flex-col place-items-center px-4 py-20 gap-6;
+}
+
+.newsletter-grid {
+  @apply w-full xl:w-3/4 mx-auto grid gap-6 grid-cols-1 md:grid-cols-3;
+}
+
+.newsletter-item {
+  @apply flex flex-col gap-2 text-ink no-underline hover:text-ink;
+}
+
+.newsletter-panel {
+  @apply w-full;
+  aspect-ratio: 4 / 3;
+}
+
+.newsletter-panel .comic-panel-container {
+  height: 100%;
+}
+
+.newsletter-title {
+  @apply font-display text-xl tracking-wide;
+}
+
+.newsletter-item:hover .newsletter-title,
+.newsletter-item:focus-visible .newsletter-title {
+  @apply underline text-accent;
+}
+
+.newsletter-date {
+  @apply text-ink-soft text-sm;
+}
+
+.newsletter-subtitle {
+  @apply text-base leading-snug;
+}

--- a/src/components/Newsletter.css
+++ b/src/components/Newsletter.css
@@ -6,7 +6,7 @@
   @apply w-full xl:w-3/4 mx-auto grid gap-6 grid-cols-1 md:grid-cols-3;
 }
 
-.newsletter-item {
+a.newsletter-item:not(.button) {
   @apply flex flex-col gap-2 text-ink no-underline hover:text-ink;
 }
 

--- a/src/components/Story.astro
+++ b/src/components/Story.astro
@@ -2,6 +2,7 @@
 import ThreePanelBlock from './ThreePanelBlock.astro';
 import ThreePanelRow from './ThreePanelRow.astro';
 import Feature from './Feature.astro';
+import Newsletter from './Newsletter.astro';
 import Events from './islands/Events';
 import siteProperties from '../customizations/siteproperties.json';
 import type { ComicPanelProps } from '../types/comicpanel';
@@ -53,7 +54,7 @@ import type { ComicPanelProps } from '../types/comicpanel';
         horizontalPosition: 'left',
       },
       {
-        text: "We also publish a free newsletter on how to use AI tools, <a href='https://knowledgeworkersguide.substack.com/'>A Knowledge Worker's Guide to the Singularity</a>.",
+        text: `We also publish a free newsletter on how to use AI tools, <a href='${siteProperties.substackUrl}/'>A Knowledge Worker's Guide to the Singularity</a>.`,
         backgroundImage: 'images/AIart.jpg',
         altText: 'An artist uses a futuristic paintbrush stylus on a digital device',
         horizontalPosition: 'right',
@@ -67,6 +68,8 @@ import type { ComicPanelProps } from '../types/comicpanel';
       },
     ] satisfies ComicPanelProps[]}
   />
+
+  <Newsletter />
 
   <Events
     client:visible

--- a/src/customizations/siteproperties.json
+++ b/src/customizations/siteproperties.json
@@ -11,6 +11,7 @@
   "convertKitFormId": "6344299",
   "convertKitDataUid": "8e2f770298",
   "zazzleUrl" : "https://www.zazzle.com/store/promptlytechnologies",
+  "substackUrl": "https://knowledgeworkersguide.substack.com",
   "socialProfiles": {
     "GitHub": "https://github.com/Promptly-Technologies-LLC",
     "Twitter": "https://twitter.com/PromptlyTech",

--- a/src/customizations/substackfeed.json
+++ b/src/customizations/substackfeed.json
@@ -1,0 +1,126 @@
+{
+  "title": "A Knowledge Worker's Guide to the Singularity",
+  "description": "Staying employed in knowledge work amid major technological disruption by AI",
+  "link": "https://knowledgeworkersguide.substack.com/",
+  "item": [
+    {
+      "title": "Steering Gemini Image Generation with a Hand-Drawn Concept Sketch",
+      "description": "From phone snap of a napkin sketch to polished generated image",
+      "link": "https://knowledgeworkersguide.substack.com/p/steering-gemini-image-generation",
+      "pubDate": "Sun, 30 Aug 2026 14:45:43 GMT",
+      "image": "https://substackcdn.com/image/fetch/$s_!GZAD!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fd62ca978-0dc9-4d31-9513-ab571aa7ec9e_3336x1280.jpeg"
+    },
+    {
+      "title": "Creating beautiful shader art with Claude Code",
+      "description": "To get quality outputs from an AI agent, have it make a detailed study of examples of quality outputs first",
+      "link": "https://knowledgeworkersguide.substack.com/p/creating-beautiful-shader-art-with",
+      "pubDate": "Sat, 14 Feb 2026 18:20:25 GMT",
+      "image": "https://substackcdn.com/image/fetch/$s_!mNGp!,w_256,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fe694b158-d17f-4cef-b791-08358c2b0d9c_1024x1024.png"
+    },
+    {
+      "title": "Days since Valentine's Day",
+      "description": "A short story",
+      "link": "https://knowledgeworkersguide.substack.com/p/days-since-valentines-day",
+      "pubDate": "Thu, 05 Feb 2026 15:46:29 GMT",
+      "image": "https://substackcdn.com/image/fetch/$s_!3Ohk!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F62470d8b-e7bd-4e25-b166-a0a8b7c3a3b4_3168x1344.png"
+    },
+    {
+      "title": "Large Language Models are already conscious",
+      "description": "... and this is the least conscious they'll ever be",
+      "link": "https://knowledgeworkersguide.substack.com/p/large-language-models-are-already",
+      "pubDate": "Wed, 28 Jan 2026 21:03:12 GMT",
+      "image": "https://substackcdn.com/image/fetch/$s_!7AJG!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fdc95ce68-bc9d-4885-80f2-8267e1a2b438_500x759.jpeg"
+    },
+    {
+      "title": "Create a realistic two-person podcast on any topic in under two minutes",
+      "description": "Google's \"NotebookLM\" generates amazing \"deep dives\" on any topic you can listen to during your commute",
+      "link": "https://knowledgeworkersguide.substack.com/p/create-a-realistic-two-person-podcast",
+      "pubDate": "Tue, 07 Jan 2025 02:05:02 GMT",
+      "image": "https://substackcdn.com/image/fetch/$s_!wB56!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fc25e6ef5-2e86-4634-a4b8-bb3aa707b79c_1024x1024.png"
+    },
+    {
+      "title": "Four prompting strategies to enslave AI chatbots as your creative writing minions",
+      "description": "A prompting toolkit for fiction writers",
+      "link": "https://knowledgeworkersguide.substack.com/p/four-prompting-strategies-to-enslave",
+      "pubDate": "Tue, 11 Jun 2024 18:08:27 GMT",
+      "image": "https://substackcdn.com/image/fetch/$s_!KZp1!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Ff6988db7-565f-46c0-9d28-be962643ab02_1456x816.png"
+    },
+    {
+      "title": "Easily fire up a powerful AI chat model that runs for free on your home computer",
+      "description": "Quickly install and run an open-source Llama model with vision capabilities on your personal Mac or Windows PC",
+      "link": "https://knowledgeworkersguide.substack.com/p/easily-fire-up-a-powerful-ai-chat",
+      "pubDate": "Thu, 30 Nov 2023 22:57:33 GMT",
+      "image": "https://substackcdn.com/image/fetch/f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Faa88028f-6b75-4a1c-9f6b-1e4ecc8b2524_960x517.jpeg"
+    },
+    {
+      "title": "Accelerate domain name availability search with ChatGPT plugins",
+      "description": "Use ChatGPT plugins to quickly find available domain names for your website",
+      "link": "https://knowledgeworkersguide.substack.com/p/accelerate-domain-name-availability",
+      "pubDate": "Mon, 13 Nov 2023 21:01:12 GMT",
+      "image": "https://substackcdn.com/image/fetch/$s_!na09!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F99d23403-48c3-4c52-a42b-8c09fd36959c_1792x1024.png"
+    },
+    {
+      "title": "A powerful tool for AI-assisted academic literature review",
+      "description": "Elicit, by Ought Inc., feels like browsing PubMed, but with more power and a little less headache",
+      "link": "https://knowledgeworkersguide.substack.com/p/a-powerful-tool-for-ai-assisted-academic",
+      "pubDate": "Thu, 25 May 2023 14:19:29 GMT",
+      "image": "https://substackcdn.com/image/fetch/$s_!e_HZ!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F31ea577d-3bda-4a18-a305-f7a213aa2f13_4032x2017.jpeg"
+    },
+    {
+      "title": "On the possibility of emergent consciousness in a large language model",
+      "description": "Could AI infer a \"grammar\" of consciousness from our language the same way it has inferred a \"grammar\" of reasoning?",
+      "link": "https://knowledgeworkersguide.substack.com/p/on-the-possibility-of-emergent-consciousness",
+      "pubDate": "Thu, 18 May 2023 14:49:18 GMT",
+      "image": "https://substackcdn.com/image/fetch/f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F48ec001a-7749-4da3-accb-705f74e23816_1024x1024.png"
+    },
+    {
+      "title": "How language models work, and what they teach us about human intelligence",
+      "description": "Language models are statistical representations of human thought-space, with profound implications for philosophy of mind",
+      "link": "https://knowledgeworkersguide.substack.com/p/how-generative-ai-uses-language-models",
+      "pubDate": "Wed, 17 May 2023 19:17:58 GMT",
+      "image": "https://substackcdn.com/image/fetch/f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F1fdf1350-c3a7-4786-a939-cdcc48a4d8a9_1024x1024.png"
+    },
+    {
+      "title": "Generating irresistible social media engagement bait with Python and GPT",
+      "description": "Let's create a Jupyter notebook for generating stunning cover images and writing engaging tweets!",
+      "link": "https://knowledgeworkersguide.substack.com/p/generating-irresistible-social-media",
+      "pubDate": "Thu, 16 Mar 2023 19:17:29 GMT",
+      "image": "https://substackcdn.com/image/fetch/f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F5a0aef95-004a-4ca7-8806-f6bfa4d36d03_1024x1024.png"
+    },
+    {
+      "title": "GPT will transform every sector of the economy, starting with software",
+      "description": "By massively lowering software development costs, OpenAI's large language model will kick off a small-business renaissance",
+      "link": "https://knowledgeworkersguide.substack.com/p/gpt-will-transform-every-sector-of",
+      "pubDate": "Mon, 23 Jan 2023 16:01:58 GMT",
+      "image": "https://substackcdn.com/image/fetch/$s_!lcl5!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fa879e0c2-1702-4c6d-ad76-edce2b847ba1_1024x1024.png"
+    },
+    {
+      "title": "Unleash the power of data visualization with ChatGPT and Python — no programming skills required!",
+      "description": "5 Simple Steps to Using AI and Python for Reproducible Data Visualization",
+      "link": "https://knowledgeworkersguide.substack.com/p/unleash-the-power-of-data-visualization",
+      "pubDate": "Sat, 17 Dec 2022 19:19:56 GMT",
+      "image": "https://substackcdn.com/image/fetch/$s_!fn1f!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F4e36da95-ece7-4a2b-9501-3c341f84ad3d_937x666.jpeg"
+    },
+    {
+      "title": "Can AI do improv comedy?",
+      "description": "Playing pun games with ChatGPT",
+      "link": "https://knowledgeworkersguide.substack.com/p/can-ai-do-improv-comedy",
+      "pubDate": "Mon, 12 Dec 2022 16:45:24 GMT",
+      "image": "https://bucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com/public/images/10e071a5-2eb1-4a79-bfe8-e68b3b67251f_1024x1024.png"
+    },
+    {
+      "title": "Comparing the two best AI image generators: Dall-E 2 and Midjourney AI",
+      "description": "What each of the major AI image gen tools is good for and how to get started using it",
+      "link": "https://knowledgeworkersguide.substack.com/p/comparing-the-two-best-ai-image-generators",
+      "pubDate": "Mon, 25 Jul 2022 21:36:57 GMT",
+      "image": "https://substackcdn.com/image/fetch/$s_!VX03!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F73676474-2ee8-44e2-8460-573c0197e1bc_1632x594.jpeg"
+    },
+    {
+      "title": "A Knowledge Worker's Guide to the Singularity",
+      "description": "A newsletter on staying employed in knowledge work through massive technological disruption in the age of AI",
+      "link": "https://knowledgeworkersguide.substack.com/p/knowledge-workers-guide",
+      "pubDate": "Fri, 15 Jul 2022 17:05:38 GMT",
+      "image": "https://substackcdn.com/image/fetch/h_600,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fbucketeer-e05bbc84-baa3-437e-9518-adb32be77984.s3.amazonaws.com%2Fpublic%2Fimages%2F8af9756b-aec1-4609-9a6e-f08bcb2ae31f_1024x1024.jpeg"
+    }
+  ]
+}

--- a/src/data/navLinks.ts
+++ b/src/data/navLinks.ts
@@ -7,6 +7,7 @@ export interface NavLink {
 export const sectionNavLinks: NavLink[] = [
   { href: '/#contact', label: 'Contact' },
   { href: '/#story', label: 'Story' },
+  { href: '/#newsletter', label: 'Newsletter' },
   { href: '/#events', label: 'Events' },
   { href: '/#credits', label: 'Credits' },
   { href: '/store/', label: 'Store' },

--- a/src/types/substackfeed.ts
+++ b/src/types/substackfeed.ts
@@ -1,0 +1,16 @@
+export type SubstackItem = {
+  title: string;
+  description: string;
+  link: string;
+  pubDate: string;
+  image?: string;
+};
+
+type SubstackFeed = {
+  title: string;
+  description: string;
+  link: string;
+  item: SubstackItem | SubstackItem[];
+};
+
+export default SubstackFeed;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Promote Sravan Parakala and Rafi Khan from Intern to Junior Software Engineer in Credits (including image alt text). Jenny Xu remains Intern.
- Fetch the Knowledge Worker's Guide Substack RSS at build time (same pattern as the Zazzle product feed) and commit a slim `substackfeed.json` — titles, subtitles, links, dates, and images, not full post HTML.
- Render the three latest posts on the home page in a new "From the Guide" section, with a Newsletter nav link and a button through to the archive.
- Wire `bun run fetchsubstack` into `bun run build` so deploys keep the listing current.

## Test plan
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] Credits shows Junior Software Engineer under Sravan and Rafi; Jenny remains Intern
- [x] Home page Newsletter section shows the three latest Substack posts with working links
- [x] Newsletter nav link is present; section is reachable
- [x] Store and legal pages still load

### Walkthrough
[credits_junior_software_engineer.mp4](https://cursor.com/agents/bc-d4373fd6-5096-4061-9b94-9bf54bafa60c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcredits_junior_software_engineer.mp4)
[Credits with Sravan and Rafi titled Junior Software Engineer](https://cursor.com/agents/bc-d4373fd6-5096-4061-9b94-9bf54bafa60c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcredits_junior_software_engineer.webp)
[newsletter_and_credits_walkthrough.mp4](https://cursor.com/agents/bc-d4373fd6-5096-4061-9b94-9bf54bafa60c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnewsletter_and_credits_walkthrough.mp4)
[From the Guide newsletter section with three latest Substack posts](https://cursor.com/agents/bc-d4373fd6-5096-4061-9b94-9bf54bafa60c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnewsletter_from_the_guide.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4373fd6-5096-4061-9b94-9bf54bafa60c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4373fd6-5096-4061-9b94-9bf54bafa60c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

